### PR TITLE
Add healthcheck options to docker-compose file

### DIFF
--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -29,10 +29,16 @@ services:
             - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
             - POSTGRES_USER=${POSTGRES_USER}
             - POSTGRES_DB=${POSTGRES_DATABASE}
+        healthcheck:
+            test: ["CMD-SHELL", "pg_isready -U postgres"]
+            interval: 5s
+            timeout: 3s
+            retries: 5    
     app:
         image: joplin/server:latest
         depends_on:
-            - db
+            db:
+                condition: service_healthy
         ports:
             - "22300:22300"
         restart: unless-stopped


### PR DESCRIPTION
Add healthcheck options to ensure postgres container is ready before starting the Joplin server container.

This is to avoid the database connection errors in server logs.

